### PR TITLE
Fix sound parsing for 1.21

### DIFF
--- a/src/main/java/de/jeff_media/drop2inventory/data/SoundData.java
+++ b/src/main/java/de/jeff_media/drop2inventory/data/SoundData.java
@@ -1,0 +1,87 @@
+package de.jeff_media.drop2inventory.data;
+
+import org.bukkit.Location;
+import org.bukkit.SoundCategory;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Simple sound descriptor used to play sounds by key.
+ */
+public class SoundData {
+
+    private final String sound;
+    private final float volume;
+    private final float pitch;
+    private final float pitchVariant;
+    private final SoundCategory soundCategory;
+
+    public SoundData(String sound) {
+        this(sound, 1f, 1f, 0f, SoundCategory.MASTER);
+    }
+
+    public SoundData(String sound, float volume, float pitch, float pitchVariant, SoundCategory category) {
+        this.sound = sound;
+        this.volume = volume;
+        this.pitch = pitch;
+        this.pitchVariant = pitchVariant;
+        this.soundCategory = category;
+    }
+
+    /**
+     * Loads a sound from a configuration section using the given prefix.
+     */
+    public static SoundData fromConfigurationSection(ConfigurationSection section, String prefix) {
+        if (prefix == null) {
+            prefix = "";
+        }
+        String effect = section.getString(prefix + "effect");
+        if (effect == null || effect.isEmpty()) {
+            throw new IllegalArgumentException("No sound effect defined");
+        }
+        effect = toSoundKey(effect);
+        float volume = (float) section.getDouble(prefix + "volume", 1f);
+        float pitch = (float) section.getDouble(prefix + "pitch", 1f);
+        float pitchVariant = (float) section.getDouble(prefix + "pitch-variant", 0f);
+        String catString = section.getString(prefix + "sound-category", SoundCategory.MASTER.name());
+        SoundCategory category;
+        try {
+            category = SoundCategory.valueOf(catString.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Unknown sound category: " + catString);
+        }
+        return new SoundData(effect.toLowerCase(Locale.ROOT), volume, pitch, pitchVariant, category);
+    }
+
+    private static String toSoundKey(String input) {
+        // If value looks like a legacy enum constant, convert it
+        if (input.equals(input.toUpperCase(Locale.ROOT)) && !input.contains(".") && !input.contains(":")) {
+            return input.toLowerCase(Locale.ROOT).replace('_', '.');
+        }
+        return input;
+    }
+
+    private float getFinalPitch() {
+        if (pitchVariant == 0f) {
+            return pitch;
+        }
+        return (float) (pitch + (ThreadLocalRandom.current().nextDouble(pitchVariant) - pitchVariant / 2));
+    }
+
+    public void playToPlayer(Player player) {
+        playToPlayer(player, player.getLocation());
+    }
+
+    public void playToPlayer(Player player, Location location) {
+        player.playSound(location, sound, soundCategory, volume, getFinalPitch());
+    }
+
+    public void playToWorld(Location location) {
+        Objects.requireNonNull(location.getWorld()).playSound(location, sound, soundCategory, volume, getFinalPitch());
+    }
+}
+

--- a/src/main/java/de/jeff_media/drop2inventory/utils/Utils.java
+++ b/src/main/java/de/jeff_media/drop2inventory/utils/Utils.java
@@ -3,7 +3,7 @@ package de.jeff_media.drop2inventory.utils;
 import de.jeff_media.drop2inventory.Main;
 import de.jeff_media.drop2inventory.config.Config;
 import de.jeff_media.drop2inventory.config.Permissions;
-import com.jeff_media.jefflib.data.SoundData;
+import de.jeff_media.drop2inventory.data.SoundData;
 import org.bukkit.*;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit;
 
 public class Utils {
 
-    private static SoundData inventoryFullSound = new SoundData(Sound.ENTITY_ITEM_PICKUP.key().asString(), 1, 1, 0.2f, SoundCategory.BLOCKS);
+    private static SoundData inventoryFullSound = new SoundData("entity.item.pickup", 1, 1, 0.2f, SoundCategory.BLOCKS);
     final Main main;
 
     public Utils(Main main) {


### PR DESCRIPTION
## Summary
- avoid shading JeffLib's legacy `SoundData`
- implement lightweight `SoundData` compatible with new interface-based sounds
- use the new helper for inventory-full sound effect

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e3f6514708332be08e1b8b937063b